### PR TITLE
Raise if x0 is outside the bounds

### DIFF
--- a/src/mutax/__init__.py
+++ b/src/mutax/__init__.py
@@ -187,7 +187,7 @@ def differential_evolution(
         x0 = eqx.error_if(
             x0,
             (x0 < lower) | (x0 > upper),
-            "Some entries in x0 lay outside the specified bounds",
+            "Some entries in x0 lie outside the specified bounds",
         )
         pop = pop.at[0].set(x0)
 

--- a/src/mutax/__init__.py
+++ b/src/mutax/__init__.py
@@ -92,7 +92,7 @@ def differential_evolution(
       `x` is a 2D array with each row being a different input to be evaluated. The
       callable should return a 1D array of function values. Setting this argument to a
       value other than 1 will override `updating` to "deferred".
-    - `x0`: Optional initial guess. Values outside `bounds` are clipped to them.
+    - `x0`: Optional initial guess. Must lie within `bounds`.
     - `vectorized`: If `True`, indicates that `func` accepts a 2D array where each
       column is a different input to be evaluated. If used, it will override `updating`
       to "deferred".
@@ -181,9 +181,15 @@ def differential_evolution(
     )
 
     if x0 is not None:
-        # Clip to the bounds, as is done with the mutant vectors below, so that the
-        # whole population -- and therefore the returned solution -- stays inside them
-        pop = pop.at[0].set(jnp.clip(jnp.asarray(x0), lower, upper))
+        x0 = jnp.asarray(x0)
+        # Checked at runtime so that it also works on traced values (e.g. under `jit`
+        # or `vmap`), unlike a plain `if`
+        x0 = eqx.error_if(
+            x0,
+            (x0 < lower) | (x0 > upper),
+            "Some entries in x0 lay outside the specified bounds",
+        )
+        pop = pop.at[0].set(x0)
 
     fitness = vmapped_func(pop)
 

--- a/src/mutax/__init__.py
+++ b/src/mutax/__init__.py
@@ -92,7 +92,7 @@ def differential_evolution(
       `x` is a 2D array with each row being a different input to be evaluated. The
       callable should return a 1D array of function values. Setting this argument to a
       value other than 1 will override `updating` to "deferred".
-    - `x0`: Optional initial guess.
+    - `x0`: Optional initial guess. Values outside `bounds` are clipped to them.
     - `vectorized`: If `True`, indicates that `func` accepts a 2D array where each
       column is a different input to be evaluated. If used, it will override `updating`
       to "deferred".
@@ -181,7 +181,9 @@ def differential_evolution(
     )
 
     if x0 is not None:
-        pop = pop.at[0].set(jnp.asarray(x0))
+        # Clip to the bounds, as is done with the mutant vectors below, so that the
+        # whole population -- and therefore the returned solution -- stays inside them
+        pop = pop.at[0].set(jnp.clip(jnp.asarray(x0), lower, upper))
 
     fitness = vmapped_func(pop)
 

--- a/tests/test_mutax.py
+++ b/tests/test_mutax.py
@@ -98,6 +98,69 @@ def test_workers_same_result(*, polish: bool) -> None:
     assert jnp.all(result3.x == result.x)
 
 
+@pytest.mark.parametrize("strategy", ["rand1bin", "best1bin"])
+@pytest.mark.parametrize("updating", ["immediate", "deferred"])
+@pytest.mark.parametrize("polish", [True, False])
+@pytest.mark.parametrize(
+    "x0", [None, [-5.0, 5.0], [-5.0, 0.0], [0.0, 5.0], [-1.0, 1.0]]
+)
+def test_x0_out_of_bounds(
+    *,
+    strategy: Literal["rand1bin", "best1bin"],
+    updating: Literal["immediate", "deferred"],
+    polish: bool,
+    x0: jax.Array | None,
+) -> None:
+    # Objective minimized at [-5, 5], which lies outside `bounds` past the lower
+    # bound in one dimension and past the upper bound in the other, so the
+    # constrained minimum is the corner [-1, 1]
+    bounds = jnp.array([[-1.0, 3.0], [-2.0, 1.0]])
+
+    def cost(x: jax.Array) -> jax.Array:
+        return jnp.sum((x - jnp.array([-5.0, 5.0])) ** 2)
+
+    result = differential_evolution(
+        cost,
+        bounds,
+        key=jax.random.key(0),
+        strategy=strategy,
+        updating=updating,
+        polish=polish,
+        x0=x0,
+    )
+    assert jnp.all(result.x >= bounds[:, 0])
+    assert jnp.all(result.x <= bounds[:, 1])
+    assert result.x == pytest.approx([-1.0, 1.0])
+
+
+@pytest.mark.parametrize(
+    ("x0", "clipped"),
+    [
+        ([-5.0, 5.0], [-1.0, 1.0]),
+        ([-5.0, 0.0], [-1.0, 0.0]),
+        ([0.0, 5.0], [0.0, 1.0]),
+        ([10.0, -10.0], [3.0, -2.0]),
+        ([-1.0, 1.0], [-1.0, 1.0]),
+        ([0.0, 0.0], [0.0, 0.0]),
+    ],
+)
+def test_x0_clipped_into_initial_population(
+    *, x0: jax.Array, clipped: jax.Array
+) -> None:
+    bounds = jnp.array([[-1.0, 3.0], [-2.0, 1.0]])
+    target = jnp.array(x0)
+
+    def cost(x: jax.Array) -> jax.Array:
+        return jnp.sum((x - target) ** 2)
+
+    # No generations are run, so the result is the best member of the initial
+    # population, and the clipped guess is the point of `bounds` closest to `target`
+    result = differential_evolution(
+        cost, bounds, key=jax.random.key(0), maxiter=0, polish=False, x0=x0
+    )
+    assert result.x == pytest.approx(clipped)
+
+
 def test_invalid() -> None:
     bounds = jnp.array([[-5.0, 5.0], [-5.0, 5.0]])
     with pytest.raises(ValueError, match="strategy"):

--- a/tests/test_mutax.py
+++ b/tests/test_mutax.py
@@ -2,6 +2,7 @@ import multiprocessing
 from collections.abc import Callable
 from typing import Literal
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import pytest
@@ -98,67 +99,98 @@ def test_workers_same_result(*, polish: bool) -> None:
     assert jnp.all(result3.x == result.x)
 
 
+# Asymmetric and per-dimension different, so that swapping the two bounds or using
+# only one dimension's bounds does not go unnoticed
+X0_BOUNDS = jnp.array([[-1.0, 3.0], [-2.0, 1.0]])
+
+
+def sphere(x: jax.Array) -> jax.Array:
+    return jnp.sum(x**2, axis=0)
+
+
 @pytest.mark.parametrize("strategy", ["rand1bin", "best1bin"])
 @pytest.mark.parametrize("updating", ["immediate", "deferred"])
 @pytest.mark.parametrize("polish", [True, False])
 @pytest.mark.parametrize(
-    "x0", [None, [-5.0, 5.0], [-5.0, 0.0], [0.0, 5.0], [-1.0, 1.0]]
+    "x0",
+    [
+        [-5.0, 0.0],  # below the lower bound
+        [0.0, 5.0],  # above the upper bound
+        [-5.0, 5.0],  # both, one in each direction
+        [10.0, -10.0],  # both, the other way around
+        [0.0, -10.0],  # below the lower bound of the second dimension only
+    ],
 )
 def test_x0_out_of_bounds(
     *,
     strategy: Literal["rand1bin", "best1bin"],
     updating: Literal["immediate", "deferred"],
     polish: bool,
-    x0: jax.Array | None,
+    x0: list[float],
 ) -> None:
-    # Objective minimized at [-5, 5], which lies outside `bounds` past the lower
-    # bound in one dimension and past the upper bound in the other, so the
-    # constrained minimum is the corner [-1, 1]
-    bounds = jnp.array([[-1.0, 3.0], [-2.0, 1.0]])
-
-    def cost(x: jax.Array) -> jax.Array:
-        return jnp.sum((x - jnp.array([-5.0, 5.0])) ** 2)
-
-    result = differential_evolution(
-        cost,
-        bounds,
-        key=jax.random.key(0),
-        strategy=strategy,
-        updating=updating,
-        polish=polish,
-        x0=x0,
-    )
-    assert jnp.all(result.x >= bounds[:, 0])
-    assert jnp.all(result.x <= bounds[:, 1])
-    assert result.x == pytest.approx([-1.0, 1.0])
+    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lay outside"):
+        differential_evolution(
+            sphere,
+            X0_BOUNDS,
+            key=jax.random.key(0),
+            strategy=strategy,
+            updating=updating,
+            polish=polish,
+            x0=jnp.array(x0),
+        )
 
 
 @pytest.mark.parametrize(
-    ("x0", "clipped"),
+    "x0",
     [
-        ([-5.0, 5.0], [-1.0, 1.0]),
-        ([-5.0, 0.0], [-1.0, 0.0]),
-        ([0.0, 5.0], [0.0, 1.0]),
-        ([10.0, -10.0], [3.0, -2.0]),
-        ([-1.0, 1.0], [-1.0, 1.0]),
-        ([0.0, 0.0], [0.0, 0.0]),
+        [0.0, 0.0],
+        [-1.0, 1.0],  # exactly on the bounds, which is allowed
+        [3.0, -2.0],  # the other two, also exactly on the bounds
+        [2.5, -1.5],
     ],
 )
-def test_x0_clipped_into_initial_population(
-    *, x0: jax.Array, clipped: jax.Array
-) -> None:
-    bounds = jnp.array([[-1.0, 3.0], [-2.0, 1.0]])
+def test_x0_in_bounds(*, x0: list[float]) -> None:
     target = jnp.array(x0)
 
     def cost(x: jax.Array) -> jax.Array:
         return jnp.sum((x - target) ** 2)
 
-    # No generations are run, so the result is the best member of the initial
-    # population, and the clipped guess is the point of `bounds` closest to `target`
+    # No generations are run, so the result can only be the best member of the
+    # initial population: this pins that `x0` is in it, and unmodified
     result = differential_evolution(
-        cost, bounds, key=jax.random.key(0), maxiter=0, polish=False, x0=x0
+        cost, X0_BOUNDS, key=jax.random.key(0), maxiter=0, polish=False, x0=target
     )
-    assert result.x == pytest.approx(clipped)
+    assert result.x == pytest.approx(x0)
+
+
+def test_x0_out_of_bounds_traced() -> None:
+    # `x0` is a tracer here, so the check cannot be a plain Python `if`
+    @eqx.filter_jit
+    def run(x0: jax.Array) -> jax.Array:
+        return differential_evolution(
+            sphere, X0_BOUNDS, key=jax.random.key(0), polish=False, x0=x0
+        ).x
+
+    assert jnp.allclose(run(jnp.array([0.0, 0.0])), 0.0, atol=1e-5)
+    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lay outside"):
+        run(jnp.array([0.0, 5.0]))
+
+
+def test_x0_out_of_bounds_vmapped() -> None:
+    run = jax.vmap(
+        lambda x0: (
+            differential_evolution(
+                sphere, X0_BOUNDS, key=jax.random.key(0), polish=False, x0=x0
+            ).x
+        )
+    )
+
+    assert jnp.allclose(run(jnp.array([[0.0, 0.0], [1.0, -1.0]])), 0.0, atol=1e-5)
+    # Only one of the two batch elements is out of bounds
+    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lay outside"):
+        run(jnp.array([[0.0, 0.0], [0.0, 5.0]]))
+    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lay outside"):
+        run(jnp.array([[0.0, 5.0], [0.0, 0.0]]))
 
 
 def test_invalid() -> None:

--- a/tests/test_mutax.py
+++ b/tests/test_mutax.py
@@ -128,7 +128,7 @@ def test_x0_out_of_bounds(
     polish: bool,
     x0: list[float],
 ) -> None:
-    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lay outside"):
+    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lie outside"):
         differential_evolution(
             sphere,
             X0_BOUNDS,
@@ -172,7 +172,7 @@ def test_x0_out_of_bounds_traced() -> None:
         ).x
 
     assert jnp.allclose(run(jnp.array([0.0, 0.0])), 0.0, atol=1e-5)
-    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lay outside"):
+    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lie outside"):
         run(jnp.array([0.0, 5.0]))
 
 
@@ -187,9 +187,9 @@ def test_x0_out_of_bounds_vmapped() -> None:
 
     assert jnp.allclose(run(jnp.array([[0.0, 0.0], [1.0, -1.0]])), 0.0, atol=1e-5)
     # Only one of the two batch elements is out of bounds
-    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lay outside"):
+    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lie outside"):
         run(jnp.array([[0.0, 0.0], [0.0, 5.0]]))
-    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lay outside"):
+    with pytest.raises(eqx.EquinoxRuntimeError, match="x0 lie outside"):
         run(jnp.array([[0.0, 5.0], [0.0, 0.0]]))
 
 


### PR DESCRIPTION
`differential_evolution` puts `x0` into the initial population without checking it against `bounds`:

```python
if x0 is not None:
    pop = pop.at[0].set(jnp.asarray(x0))
```

Everywhere else in the same function a point is kept inside the box: the Latin-hypercube init is in-bounds by construction, mutants get `jnp.clip(mutant, lower, upper)`, and a polished result is accepted only if `jnp.all((result.x >= lower) & (result.x <= upper))`. `x0` is the only way in.

That last guard is what makes this a real problem rather than just a sloppy start: it only vets the *polished* candidate, never `best` itself. Since a user normally passes `x0` precisely because it scores well, an out-of-bounds guess wins selection every generation and comes back as `result.x`, outside the bounds the caller declared, with no warning. `func` also gets evaluated there, which matters whenever the bounds *are* the objective's domain.

```python
def cost(x):
    return jnp.sum((x - 5.0) ** 2)      # minimum at 5, outside the box

bounds = jnp.array([[-1.0, 1.0]])

differential_evolution(cost, bounds, x0=jnp.array([5.0]), key=jax.random.key(0)).x
# [5.]      <- outside bounds
differential_evolution(cost, bounds, key=jax.random.key(0)).x
# [1.]      <- correct without x0
```

## Extent

I swept the full option surface — `strategy` x `updating` x `workers` in `(1, 2, -1, callable)` x `polish` x `vectorized`, 52 valid combinations — with the objective's minimum placed outside the box on the same side as `x0`:

| case | configs | out-of-bounds `result.x` |
|---|---|---|
| minimum `+5`, `x0 = [5, 5]` | 52 | 52 |
| minimum `-5`, `x0 = [-5, -5]` | 52 | 52 |
| minimum `+5`, `x0 = [0, 5]` | 52 | 52 |
| minimum `-5`, `x0 = [-5, 0]` | 52 | 52 |
| minimum `+5`, `x0 = [0, 0]` (control) | 52 | 0 |
| `x0 = None` (control, both directions) | 104 | 0 |

208/208 violating configs fail, 156/156 controls pass — it is option-independent, and symmetric in both directions of violation. But it is genuinely a single site: `x0` is the only user input that is a point in the search space; `strategy`, `updating`, `workers` and `vectorized` are static and already validated with an explicit `raise ValueError`. Nothing else needed fixing.

(The 4 `callable workers` + `polish` combinations are excluded from the sweep because they crash on any scalar-valued objective, for an unrelated reason in `single_func` that I'll report separately.)

## The fix

Reject the out-of-bounds `x0`, with scipy's message:

```python
x0 = jnp.asarray(x0)
x0 = eqx.error_if(
    x0,
    (x0 < lower) | (x0 > upper),
    "Some entries in x0 lay outside the specified bounds",
)
pop = pop.at[0].set(x0)
```

This matches `scipy/optimize/_differentialevolution.py`, including the strict comparison, so a point exactly on a bound is accepted:

```python
if x0 is not None:
    # scale to within unit interval and
    # ensure parameters are within bounds.
    x0_scaled = self._unscale_parameters(np.asarray(x0))
    if ((x0_scaled > 1.0) | (x0_scaled < 0.0)).any():
        raise ValueError(
            "Some entries in x0 lay outside the specified bounds"
        )
```

An earlier revision of this PR clipped instead, on the grounds that a plain Python `if` cannot work here — `differential_evolution` is `@eqx.filter_jit` and `x0` is a tracer in normal use, so the comparison dies with `TracerBoolConversionError`. That is true of a Python `if`, but not of `eqx.error_if`, which is designed for exactly this and defers the check to runtime. The check also sits in the one-time initialisation, not in the generation loop, so calling it a hot path was wrong of me.

One caveat worth knowing: if a caller wraps the whole thing in a plain `jax.jit` rather than `eqx.filter_jit`, equinox cannot attach its own traceback and the failure surfaces as `JaxRuntimeError: INTERNAL: CpuCallback error ...` with the message buried inside. It still fails, just less readably; equinox says as much in the error text. Calling `differential_evolution` directly, or under `eqx.filter_jit`, gives a clean `EquinoxRuntimeError`.

## Tests

- `test_x0_out_of_bounds` — asymmetric per-dimension bounds `[[-1, 3], [-2, 1]]` across `strategy` x `updating` x `polish` x 5 out-of-bounds values of `x0`, covering both directions in each dimension separately and together (40 cases).
- `test_x0_in_bounds` — `maxiter=0` so no generations run and the result can only come from the seed, pinning that an in-bounds `x0` is still placed in the population unmodified. Includes the two corners that lie exactly on the bounds, which must not raise.
- `test_x0_out_of_bounds_traced` and `test_x0_out_of_bounds_vmapped` — `x0` as a tracer under `eqx.filter_jit`, and under `jax.vmap` where only one batch element is out of bounds (either one).

I mutated the fix in both directions — checking one bound only, using dimension 0's bounds for both dimensions, swapping `lower`/`upper`, making the comparison non-strict so points on the bounds are rejected, reducing with `all()` instead of `any()`, dropping `x0` altogether, and discarding the return value of `eqx.error_if` so the check is eliminated as dead code — and each of the nine reddens, with the two intended-equivalent variants staying green.

`uv run pytest` goes 116 passed / 16 skipped to 162 passed / 16 skipped. `ruff check`, `ruff format --check` and `ty check` are clean.
