### PR TITLE
Derive single_func from the calling convention, not from workers

### DIFF
--- a/src/mutax/__init__.py
+++ b/src/mutax/__init__.py
@@ -134,37 +134,36 @@ def differential_evolution(
         warnings.warn(msg, UserWarning, stacklevel=2)
         updating = "deferred"
 
+    # How a single point is evaluated depends on the calling convention of `func`
+    # (i.e. on `vectorized`) alone, never on `workers`, which only decides how a
+    # whole population is spread over devices
+    if vectorized:
+
+        def single_func(x: jax.Array) -> jax.Array:
+            # `x` is a single point, so it is passed as the only column of a 2D array
+            return func(x[:, None])[0]
+    else:
+        single_func = func
+
     if workers == 1:
         if vectorized:
-
-            def single_func(x: jax.Array) -> jax.Array:
-                return func(x[None, :])[0]
 
             def vmapped_func(x: jax.Array) -> jax.Array:
                 return func(x.T)
         else:
-            single_func = func
             vmapped_func = jax.vmap(func)
     elif callable(workers):
         if vectorized:
             msg = "If 'workers' is a callable, 'vectorized' must be False"
             raise ValueError(msg)
 
-        def single_func(x: jax.Array) -> jax.Array:
-            return func(x[None, :])[0]
-
         def vmapped_func(x: jax.Array) -> jax.Array:
             return workers(func, x)  # ty: ignore[call-top-callable,invalid-return-type]
     else:
         max_devices = None if workers == -1 else workers
         if vectorized:
-
-            def single_func(x: jax.Array) -> jax.Array:
-                return func(x[None, :])[0]
-
             vmapped_func = parallelize(lambda x: func(x.T), max_devices=max_devices)
         else:
-            single_func = func
             vmapped_func = parallelize(jax.vmap(func), max_devices=max_devices)
 
     # Initialize population (Latin hypercube sampling)
@@ -284,7 +283,7 @@ def differential_evolution(
                 trial, key = make_trial(pop, fitness, i, key)
 
                 # Selection
-                f_trial = func(trial)
+                f_trial = single_func(trial)
                 better = f_trial < fitness[i]
                 pop = pop.at[i].set(jnp.where(better, trial, pop[i]))
                 fitness = fitness.at[i].set(jnp.where(better, f_trial, fitness[i]))

--- a/tests/test_mutax.py
+++ b/tests/test_mutax.py
@@ -193,6 +193,143 @@ def test_x0_out_of_bounds_vmapped() -> None:
         run(jnp.array([[0.0, 5.0], [0.0, 0.0]]))
 
 
+def scalar_rosenbrock(x: jax.Array) -> jax.Array:
+    """`rosenbrock`, but returning a scalar, as `func` is documented to do."""
+    return jnp.sum(100.0 * (x[1:] - x[:-1] ** 2.0) ** 2.0 + (1 - x[:-1]) ** 2.0)
+
+
+def evaluate(
+    func: Callable[[jax.Array], jax.Array], x: jax.Array, *, vectorized: bool
+) -> jax.Array:
+    """Evaluate `func` at the single point `x`, using its own calling convention."""
+    return func(x[:, None])[0] if vectorized else func(x)
+
+
+@pytest.mark.parametrize("strategy", ["rand1bin", "best1bin"])
+@pytest.mark.parametrize("updating", ["immediate", "deferred"])
+@pytest.mark.parametrize("workers", [1, 2, -1, pmap])
+@pytest.mark.parametrize("vectorized", [False, True])
+@pytest.mark.parametrize("func", [rosenbrock, sphere])
+def test_reported_fun_matches_objective(
+    *,
+    strategy: Literal["rand1bin", "best1bin"],
+    updating: Literal["immediate", "deferred"],
+    workers: int | Callable[[Callable[[jax.Array], jax.Array], jax.Array], jax.Array],
+    vectorized: bool,
+    func: Callable[[jax.Array], jax.Array],
+) -> None:
+    if callable(workers) and vectorized:
+        pytest.skip("Cannot use callable workers with vectorized=True")
+
+    bounds = jnp.array([[-5.0, 5.0], [-5.0, 5.0]])
+    # With zero tolerances the run never converges early, so exactly `maxiter`
+    # generations are evolved and it is the BFGS polish that decides the answer
+    result = differential_evolution(
+        func,
+        bounds,
+        key=jax.random.key(0),
+        strategy=strategy,
+        updating=updating,
+        workers=workers,
+        vectorized=vectorized,
+        polish=True,
+        maxiter=10,
+        tol=0.0,
+        atol=0.0,
+    )
+    assert result.fun == pytest.approx(
+        evaluate(func, result.x, vectorized=vectorized), rel=1e-4, abs=1e-6
+    )
+
+
+@pytest.mark.parametrize("workers", [1, 2, -1, pmap])
+@pytest.mark.parametrize("polish", [True, False])
+def test_scalar_objective(
+    *,
+    workers: int | Callable[[Callable[[jax.Array], jax.Array], jax.Array], jax.Array],
+    polish: bool,
+) -> None:
+    bounds = jnp.array([[-5.0, 5.0], [-5.0, 5.0]])
+    result = differential_evolution(
+        scalar_rosenbrock,
+        bounds,
+        key=jax.random.key(42),
+        workers=workers,
+        polish=polish,
+    )
+    assert result.success
+    assert result.x == pytest.approx([1.0, 1.0])
+    assert result.fun == pytest.approx(scalar_rosenbrock(result.x), abs=1e-6)
+
+
+def test_vectorized_func_only_receives_columns() -> None:
+    bounds = jnp.array([[-5.0, 5.0], [-5.0, 5.0]])
+    shapes = []
+
+    def recording(x: jax.Array) -> jax.Array:
+        shapes.append(x.shape)
+        return rosenbrock(x)
+
+    differential_evolution(
+        recording,
+        bounds,
+        key=jax.random.key(0),
+        vectorized=True,
+        polish=True,
+        maxiter=10,
+        tol=0.0,
+        atol=0.0,
+    )
+
+    assert shapes
+    # `bounds` has two rows, so every call must be (2, S): the polish evaluates a
+    # single point, which is one column and not a one-row array
+    assert all(shape[0] == 2 for shape in shapes), shapes
+    assert (2, 1) in shapes, shapes
+
+
+@pytest.mark.parametrize("polish", [True, False])
+def test_vectorized_same_result(*, polish: bool) -> None:
+    bounds = jnp.array([[-5.0, 5.0], [-5.0, 5.0]])
+    result = differential_evolution(
+        rosenbrock,
+        bounds,
+        key=jax.random.key(42),
+        polish=polish,
+        updating="deferred",
+        maxiter=10,
+        tol=0.0,
+        atol=0.0,
+    )
+    result2 = differential_evolution(
+        rosenbrock,
+        bounds,
+        key=jax.random.key(42),
+        polish=polish,
+        updating="deferred",
+        maxiter=10,
+        tol=0.0,
+        atol=0.0,
+        vectorized=True,
+    )
+    result3 = differential_evolution(
+        rosenbrock,
+        bounds,
+        key=jax.random.key(42),
+        polish=polish,
+        updating="deferred",
+        maxiter=10,
+        tol=0.0,
+        atol=0.0,
+        workers=pmap,
+    )
+
+    assert result2.x == pytest.approx(result.x, abs=1e-6)
+    assert result3.x == pytest.approx(result.x, abs=1e-6)
+    assert result2.fun == pytest.approx(result.fun, abs=1e-6)
+    assert result3.fun == pytest.approx(result.fun, abs=1e-6)
+
+
 def test_invalid() -> None:
     bounds = jnp.array([[-5.0, 5.0], [-5.0, 5.0]])
     with pytest.raises(ValueError, match="strategy"):


### PR DESCRIPTION
`single_func` — the single-point objective handed to the BFGS polish — is derived
separately inside each `workers` branch, and three of the five copies are wrong. It
actually depends on `vectorized` alone, so this replaces the five copies with one
derivation. Found while auditing the option surface for #64.

### What goes wrong

| `workers` | `vectorized` | `single_func` on `main` | |
|---|---|---|---|
| `1` | `False` | `func` | correct |
| `1` | `True` | `func(x[None, :])[0]` | wrong axis |
| `2` / `-1` | `False` | `func` | correct |
| `2` / `-1` | `True` | `func(x[None, :])[0]` | wrong axis |
| callable | (forced `False`) | `func(x[None, :])[0]` | `func` is not vectorized here |

**Wrong axis.** With `vectorized=True` the docstring says "each column is a different
input", and `vmapped_func` follows it: `func(x.T)`, the population being stored one
individual per row. `x[None, :]` is a `(1, dim)` row, which under that convention reads as
`dim` separate one-parameter inputs — the transpose of what `func` expects. For this
repo's own `rosenbrock` that makes `single_func` the constant `0.0`, because the `x[1:]` /
`x[:-1]` slices of a one-row array come out empty:

```python
>>> rosenbrock(jnp.array([3.0, -4.0]))              # true value
Array(16904., dtype=float32)
>>> rosenbrock(jnp.array([3.0, -4.0])[None, :])[0]  # what the polish minimizes
Array(0., dtype=float32)
```

Minimizing a constant converges immediately with `fun=0.0`, so the acceptance guard
(`result.success & (result.fun < best_fitness) & in bounds`) passes every time. The
returned `x` is the unpolished DE best, `fun` is `0.0` no matter what that point is worth,
and `jac` / `hess_inv` are the derivatives of the constant.

For `sphere` (`jnp.sum(x**2, axis=0)`) the row form degenerates to the first coordinate's
`x[0]**2` instead, so the polish optimizes that one coordinate and leaves the others — it
can return a worse point than the plain path:

```
maxiter=3, tol=atol=0, key=0, bounds=[(-5,5),(-5,5)]
vectorized=False   x=[0. 0.]           fun=0.0
vectorized=True    x=[0. -0.4585471]   fun=0.0    (true value at that x: 0.21)
```

**Callable `workers`.** That branch requires `vectorized=False`, so `func` takes a 1-D
array and returns a scalar, exactly as documented. Wrapping it indexes a 0-d array:

```python
>>> differential_evolution(lambda x: jnp.sum(x**2), bounds, workers=pmap)
IndexError: Too many indices: array is 0-dimensional, but 1 were indexed
```

The current tests miss all of this because `rosenbrock` and `sphere` are written with
`axis=0` and slicing, so they tolerate a 2-D argument, and because the `polish=True` cases
only assert the converged optimum — which the DE loop reaches on its own, with or without
a working polish.

### The fix

"Evaluate `func` at one point" is decided by `func`'s calling convention and nothing else;
`workers` only decides how a whole population is spread over devices. Hoisting the
derivation out of the `workers` dispatch removes the duplication that let the branches
drift apart:

```python
if vectorized:
    def single_func(x):
        return func(x[:, None])[0]
else:
    single_func = func
```

This is also what SciPy does. Its polish objective is a single expression that collapses
to exactly these two forms (`scipy/optimize/_differentialevolution.py`):

```python
def _f(x):
    return list(self._mapwrapper(self.func, np.atleast_2d(x)))[0]
```

with `_mapwrapper = lambda func, x: np.atleast_1d(func(x.T))` when `vectorized`, and the
plain map otherwise. Recording the shapes SciPy hands a vectorized objective (scipy
1.18.0, `maxiter=3`, 2 parameters) gives `{(2, 30): 4, (2, 1): 9}` — the polish sends a
single column, never a row.

One further change: `func(trial)` becomes `single_func(trial)` in the `updating="immediate"`
selection step. That is a no-op today, since `"immediate"` survives only when
`workers == 1` and `vectorized` is false, where `single_func is func` — but it was the
second place that open-coded "evaluate one point", and the two only agreed by accident.

### Audit

Whole option surface — `workers` x `vectorized` x `strategy` x `updating` x `polish`, with
two dual-convention objectives and two scalar-only ones, 176 configurations — against the
invariant `result.fun == func(result.x)`:

| | before | after |
|---|---|---|
| pass | 136 | 176 |
| wrong `fun` | 32 | 0 |
| `IndexError` | 8 | 0 |

Every one of the 40 failures has `polish=True` and either `vectorized=True` or a callable
`workers`; `polish=False` is unaffected throughout, `single_func` having no other use.

### Tests

- `test_reported_fun_matches_objective` — the invariant above over strategy x updating x
  workers x vectorized x objective (56 cases). 32 fail on `main`.
- `test_scalar_objective` — an objective returning a scalar, as `func` is documented to,
  with each `workers` setting. `workers=pmap, polish=True` raises `IndexError` on `main`.
- `test_vectorized_func_only_receives_columns` — records the shapes a `vectorized=True`
  objective is called with, and asserts they are all `(dim, S)` and that `(dim, 1)` occurs,
  i.e. the polish sends one column. This rejects both wrapping on the wrong axis and not
  wrapping at all.
- `test_vectorized_same_result` — `vectorized=True` and a callable `workers` must agree
  with the plain path, in the spirit of the existing `test_workers_same_result`.

`uv run pytest`: 229 passed, 24 skipped (162 / 16 before). `ruff check`,
`ruff format --check` and `uv run ty check` are clean.
